### PR TITLE
Update Docker command for accessing Postgres shell

### DIFF
--- a/docs/self-hosting/guides/docker.md
+++ b/docs/self-hosting/guides/docker.md
@@ -242,7 +242,7 @@ WARNING: database "<your_database_name>" has a collation version mismatch
 You can fix this by running the following command:
 
 ```bash
-docker compose exec database psql -U <your_database_username>
+docker compose exec database psql <your_database_name> -U <your_database_username>
 ```
 
 This will open a Postgres shell. Then you can run the following command to update the collation:


### PR DESCRIPTION
This expands the `psql` command to include the database name.

Without the database name, `psql` will assume the name is the same as the database username

It took me a minute to understand why it couldn't exec into the database container. As I had changed the username from the default suggestions